### PR TITLE
Add required container port

### DIFF
--- a/03-image-and-chart.md
+++ b/03-image-and-chart.md
@@ -98,6 +98,7 @@ spec:
           image: ghcr.io/${{ values.githubRepositoryOrg }}/${{ values.githubRepositoryName }}:{% raw %}{{ .Values.image.tag }}{% endraw %}
           ports:
             - name: http
+              containerPort: 8080
 ```
 
 Now we will add a `.github` folder that will contain Github Actions workflow


### PR DESCRIPTION
Container port [is required](https://pkg.go.dev/k8s.io/api/core/v1#ContainerPort) and without I got the error message
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0].ports[0]): missing required field "containerPort" in io.k8s.api.core.v1.ContainerPort
```